### PR TITLE
暴露Table的只读配置

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -364,4 +364,35 @@ abstract class Table extends \ArrayObject
         
         return $query->querySync();
     }
+    
+    public static function getKeyspace()
+    {
+        return static::$_keyspace;
+    }
+
+    public static function getColumns()
+    {
+        return static::$_columns;
+    }
+
+    public static function getTableName()
+    {
+        return static::$_name;
+    }
+
+    public static function getPrimary()
+    {
+        return static::$_primary;
+    }
+
+    public static function getReadConsistency()
+    {
+        return static::$_readConsistency;
+    }
+
+    public static function getWriteConsistency()
+    {
+        return static::$_writeConsistency;
+    }
+    
 }


### PR DESCRIPTION
暴露只读配置可为外部类提供更多信息。
例如外部希望获取到Column定义来提供根据字段名自动识别类型的需求。
